### PR TITLE
nautilus: resolve GVFS/SMB paths correctly and show clean URIs

### DIFF
--- a/nautilus/bcompare-nautilus.c
+++ b/nautilus/bcompare-nautilus.c
@@ -139,9 +139,43 @@ static gboolean file_is_dir(BCompareExt *bcobj, char *filepath)
 	return isdir;
 }
 
+/* Resolves the real, stat()-able filesystem path for a selected item.
+ * g_filename_from_uri() only understands file:// URIs and returns NULL for
+ * anything GVFS-backed, so go through the GFile instead: for a GVFS location
+ * with an active FUSE mount this yields the /run/user/<uid>/gvfs/... path
+ * that file_is_dir() and bcompare both need. */
 static gchar * nautilus_to_path(NautilusFileInfo* file)
 {
-	return g_filename_from_uri(nautilus_file_info_get_uri(file), NULL, NULL);
+	GFile *location = nautilus_file_info_get_location(file);
+	gchar *path = g_file_get_path(location);
+
+	g_object_unref(location);
+	if (path == NULL) path = nautilus_file_info_get_uri(file);
+	return path;
+}
+
+/* Maps a real path to what bcompare should show in its address bar: the
+ * original URI for GVFS-backed locations (smb://server/share/... rather than
+ * the FUSE mount point), and the unchanged plain path for anything local. */
+static gchar * path_to_display(const gchar *path)
+{
+	GFile *location = g_file_new_for_commandline_arg(path);
+	gchar *uri = g_file_get_uri(location);
+
+	g_object_unref(location);
+	if ((uri == NULL) || g_str_has_prefix(uri, "file://")) {
+		g_free(uri);
+		return g_strdup(path);
+	}
+	return uri;
+}
+
+/* Display string for one bcompare argument, or "" when nothing is selected.
+ * Always returns a new string the caller must g_free(). */
+static gchar * display_arg(GString *path)
+{
+	if (path == NULL) return g_strdup("");
+	return path_to_display(path->str);
 }
 
 /*************************************************************
@@ -192,21 +226,23 @@ static void select_center_action(BcMenuItem *item, BCompareExt *bcobj)
 static void edit_file_action(BcMenuItem *item, BCompareExt *bcobj)
 {
 	GString *edit_file;
+	gchar *edit_disp;
 	char *argv[5];
 
 	edit_file =
 		(GString *)g_object_get_data((GObject *)item, "bcext::edit_file");
+	edit_disp = display_arg(edit_file);
+
 	argv[0] = "bcompare";
 	argv[1] = "bcompare";
 	argv[2] = "-edit";
-	if (edit_file != NULL)
-		argv[3] = edit_file->str;
-	else argv[3] = "";
+	argv[3] = edit_disp;
 	argv[4] = 0;
 
 	spawn_bc(argv);
 	clear_selections(bcobj);
 
+	g_free(edit_disp);
 	if (edit_file != NULL) g_string_free(edit_file, TRUE);
 }
 
@@ -214,6 +250,7 @@ static void compare_action(BcMenuItem *item, BCompareExt *bcobj)
 {
 	GString *left_file, *right_file;
 	GString *msg = g_string_new("");
+	gchar *left_disp, *right_disp;
 	char *fileviewer;
 	char *argv[6];
 	int cnt = 0;
@@ -225,24 +262,25 @@ static void compare_action(BcMenuItem *item, BCompareExt *bcobj)
 	fileviewer =
 		(char *)g_object_get_data((GObject *)item, "bcext::fileviewer");
 
+	left_disp = display_arg(left_file);
+	right_disp = display_arg(right_file);
+
 	argv[cnt++] = "bcompare";
 	argv[cnt++] = "bcompare";
 	if (strcmp(fileviewer, "") != 0) {
 		g_string_printf(msg, "-fv=\"%s\"", fileviewer);
 		argv[cnt++] = msg->str;
 	}
-	if (left_file != NULL)
-		argv[cnt++] = left_file->str;
-	else argv[cnt++] = "";
-	if (right_file != NULL)
-		argv[cnt++] = right_file->str;
-	else argv[cnt++] = "";
+	argv[cnt++] = left_disp;
+	argv[cnt++] = right_disp;
 	argv[cnt++] = 0;
 
 	spawn_bc(argv);
 	clear_selections(bcobj);
 
 	g_string_free(msg, TRUE);
+	g_free(left_disp);
+	g_free(right_disp);
 	if (left_file != NULL) g_string_free(left_file, TRUE);
 	if (right_file != NULL) g_string_free(right_file, TRUE);
 }
@@ -250,6 +288,7 @@ static void compare_action(BcMenuItem *item, BCompareExt *bcobj)
 static void sync_action(BcMenuItem *item, BCompareExt *bcobj)
 {
 	GString *left_folder, *right_folder;
+	gchar *left_disp, *right_disp;
 	char *argv[6];
 
 	left_folder =
@@ -257,20 +296,21 @@ static void sync_action(BcMenuItem *item, BCompareExt *bcobj)
 	right_folder =
 		(GString *)g_object_get_data((GObject *)item, "bcext::right_folder");
 
+	left_disp = display_arg(left_folder);
+	right_disp = display_arg(right_folder);
+
 	argv[0] = "bcompare";
 	argv[1] = "bcompare";
 	argv[2] = "-sync";
-	if (left_folder != NULL)
-		argv[3] = left_folder->str;
-	else argv[3] = "";
-	if (right_folder != NULL)
-		argv[4] = right_folder->str;
-	else argv[4] = "";
+	argv[3] = left_disp;
+	argv[4] = right_disp;
 	argv[5] = 0;
 
 	spawn_bc(argv);
 	clear_selections(bcobj);
 
+	g_free(left_disp);
+	g_free(right_disp);
 	if (left_folder != NULL) g_string_free(left_folder, TRUE);
 	if (right_folder != NULL) g_string_free(right_folder, TRUE);
 }
@@ -278,6 +318,7 @@ static void sync_action(BcMenuItem *item, BCompareExt *bcobj)
 static void merge_action(BcMenuItem *item, BCompareExt *bcobj)
 {
 	GString *left_file, *right_file, *center_file;
+	gchar *left_disp, *right_disp, *center_disp;
 	char *argv[7];
 
 	left_file =
@@ -287,23 +328,24 @@ static void merge_action(BcMenuItem *item, BCompareExt *bcobj)
 	center_file =
 		(GString *)g_object_get_data((GObject *)item, "bcext::center_file");
 
+	left_disp = display_arg(left_file);
+	right_disp = display_arg(right_file);
+	center_disp = display_arg(center_file);
+
 	argv[0] = "bcompare";
 	argv[1] = "bcompare";
 	argv[2] = "-fv=\"\"Text Merge\"\"";
-	if (left_file != NULL)
-		argv[3] = left_file->str;
-	else argv[3] = "";
-	if (right_file != NULL)
-		argv[4] = right_file->str;
-	else argv[4] = "";
-	if (center_file != NULL)
-		argv[5] = center_file->str;
-	else argv[5] = "";
+	argv[3] = left_disp;
+	argv[4] = right_disp;
+	argv[5] = center_disp;
 	argv[6] = 0;
 
 	spawn_bc(argv);
 	clear_selections(bcobj);
 
+	g_free(left_disp);
+	g_free(right_disp);
+	g_free(center_disp);
 	if (left_file != NULL) g_string_free(left_file, TRUE);
 	if (right_file != NULL) g_string_free(right_file, TRUE);
 	if (center_file != NULL) g_string_free(center_file, TRUE);


### PR DESCRIPTION
## The bug

`nautilus_to_path()` called `g_filename_from_uri()` directly on the file's URI. That function only understands `file://` and returns `NULL` for anything GVFS-backed, so on `smb://` (and `sftp://`, etc.) shares "Select Left File/Folder for Compare" silently captured nothing and the follow-up "Compare to" never worked.

## The fix

Resolve the location through its `GFile` instead. For a GVFS mount with an active FUSE bridge this yields the real `/run/user/<uid>/gvfs/...` path that both `file_is_dir()` and `bcompare` need.

That path works but is unpleasant to look at in Beyond Compare's address bar, so it's converted back to the original URI at the single point where that matters — the `argv` handed to `bcompare`. `path_to_display()` maps a GVFS-backed path to its clean `smb://server/share/...` form and leaves local paths untouched.

Keeping the conversion at the `argv` boundary means everything upstream of it — the selection storage files, the menu-item data, and every `file_is_dir()` call including the delayed one that runs against a path round-tripped through `LeftFileStorage` on a later right-click — keeps working with real, stat()-able paths exactly as before. The on-disk format of the selection files is unchanged, and `beyondcompare_get_file_items()`, the `BCompareExt` struct, and all six `*_mitem()` builders are untouched.

## Scope

Nautilus only. Thunar has the identical bug in `bcompare-thunarx.c` (`thunarx_to_path()`), but it's unverified here and belongs in its own change.

## On the approach

An earlier version of this fix carried two parallel values (real path + display URI) through the struct, the menu items, and a two-line selection-file format. It works, but it's ~3x the diff and changes the storage format. It's preserved at [`alt/dual-value-carry`](https://github.com/mward5/BCompare-LinuxMenus/tree/alt/dual-value-carry) for comparison.

Converting at the `argv` boundary turned out to be much simpler, mainly because GIO already performs the FUSE-path to URI mapping natively via `g_file_new_for_commandline_arg()` + `g_file_get_uri()` — no parsing of GVFS's internal mount naming is required, including for filenames containing commas, which that naming scheme uses as its own separator.

## Testing

Verified against a live `smb://` share, both the multi-select workflow and the two-step "Select Left..." then right-click "Compare to" workflow:

- [x] local file vs. local file — address bar unchanged from current behavior
- [x] local folder vs. local folder — still detected as folders
- [x] `smb://` file vs. `smb://` file
- [x] `smb://` file vs. local file (cross-location, two-step)
- [x] `smb://` folder compare — detected as a folder *and* shows the clean URI
- [x] filenames containing spaces and commas — no percent-escapes visible in the address bar
- [x] builds clean with `make -C nautilus ext64` (only pre-existing GTK deprecation warnings)
